### PR TITLE
Fix the CV PDF build fonts, and add the Khalil Third Circuit declaration

### DIFF
--- a/.github/workflows/cv-pdf.yml
+++ b/.github/workflows/cv-pdf.yml
@@ -7,78 +7,145 @@ on:
       - GraemeBlair-CV.tex
       - .github/workflows/cv-pdf.yml
       - .github/fonts/**
+  pull_request:
+    paths:
+      - GraemeBlair-CV.tex
+      - .github/workflows/cv-pdf.yml
+      - .github/fonts/**
+
+concurrency:
+  group: cv-pdf-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
-  build-and-deploy:
-    if: github.ref != 'refs/heads/gh-pages'
-    runs-on: ubuntu-latest
+  build:
+    # GraemeBlair-CV.tex is set in Hoefler Text and Monaco. Those are macOS
+    # system fonts and are not redistributable, so they cannot be vendored into
+    # this repository and installed on a Linux runner -- the build has to run on
+    # macOS, where XeTeX picks them up from the system font book. Substituting
+    # free lookalikes changes the typography of the published CV, so don't.
+    runs-on: macos-latest
+    timeout-minutes: 60
     permissions:
       contents: write
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+        uses: actions/checkout@v5
+
+      - name: Install fonts bundled in this repository
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/Library/Fonts"
+          shopt -s nullglob
+          installed=0
+          for font in .github/fonts/*.ttf .github/fonts/*.otf .github/fonts/*.ttc; do
+            cp "$font" "$HOME/Library/Fonts/"
+            echo "installed $(basename "$font")"
+            installed=$((installed + 1))
+          done
+          echo "installed $installed bundled font file(s)"
+
+      - name: Install TeX Live
+        run: |
+          set -euo pipefail
+          # mactex-no-gui is the full TeX Live distribution without the GUI
+          # front-ends. It is a single download, so unlike BasicTeX + tlmgr it
+          # does not depend on CTAN mirror availability at build time.
+          brew install --cask mactex-no-gui
+          echo "/Library/TeX/texbin" >> "$GITHUB_PATH"
+
+      - name: Verify the CV fonts are visible to XeTeX
+        run: |
+          set -euo pipefail
+          cat > font-probe.tex <<'PROBE'
+          \documentclass{article}
+          \usepackage{fontspec}
+          \newcommand{\probe}[1]{\IfFontExistsTF{#1}{\typeout{FONT-OK: #1}}{\typeout{FONT-MISSING: #1}}}
+          \begin{document}
+          \probe{Hoefler Text}
+          \probe{Hoefler Text Black}
+          \probe{Hoefler Text Italic}
+          \probe{Monaco}
+          font probe
+          \end{document}
+          PROBE
+
+          xelatex -interaction=nonstopmode -halt-on-error font-probe.tex >/dev/null
+          grep 'FONT-OK\|FONT-MISSING' font-probe.log || true
+
+          if grep -q 'FONT-MISSING' font-probe.log; then
+            echo "::error::A font required by GraemeBlair-CV.tex is not installed on this runner."
+            grep 'FONT-MISSING' font-probe.log
+            exit 1
+          fi
 
       - name: Compile GraemeBlair-CV.tex with XeLaTeX
-        uses: xu-cheng/latex-action@v3
-        with:
-          root_file: GraemeBlair-CV.tex
-          latexmk_use_xelatex: true
-          pre_compile: |
-            mkdir -p ~/.local/share/fonts
-            copied_font=0
-            if [ -d .github/fonts ]; then
-              for font_file in .github/fonts/Hoefler* .github/fonts/Monaco* .github/fonts/Gentium* .github/fonts/GenBas* .github/fonts/GenBkBas*; do
-                [ -f "$font_file" ] || continue
-                cp "$font_file" ~/.local/share/fonts/
-                copied_font=1
-              done
-            fi
-            if [ "$copied_font" -eq 1 ] && command -v fc-cache >/dev/null 2>&1; then
-              fc-cache -f
-            fi
+        run: |
+          set -euo pipefail
+          latexmk -xelatex -halt-on-error -file-line-error -interaction=nonstopmode GraemeBlair-CV.tex
 
-      - name: Replace CV PDF on gh-pages
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Verify the PDF was typeset in the intended fonts
+        run: |
+          set -euo pipefail
+          # Guard against a silent regression to substituted fonts: if XeTeX had
+          # fallen back, these font families would never have been created.
+          for family in "HoeflerText(0)" "Monaco(0)"; do
+            if ! grep -qF "Font family '${family}' created" GraemeBlair-CV.log; then
+              echo "::error::GraemeBlair-CV.pdf was not typeset with ${family}."
+              exit 1
+            fi
+            echo "ok: ${family}"
+          done
+
+          if [ ! -s GraemeBlair-CV.pdf ]; then
+            echo "::error::GraemeBlair-CV.pdf is missing or empty."
+            exit 1
+          fi
+          ls -l GraemeBlair-CV.pdf
+
+      - name: Upload build output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cv-pdf
+          path: |
+            GraemeBlair-CV.pdf
+            GraemeBlair-CV.log
+          if-no-files-found: warn
+
+      - name: Publish PDF to the site
+        # Only the default branch is published. Feature branches and pull
+        # requests build for verification but must not overwrite the live PDF.
+        if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         run: |
           set -euo pipefail
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          publish_dir="$(mktemp -d)"
-          cleanup() {
-            rm -rf "$publish_dir"
-          }
-          trap cleanup EXIT
-
-          remote_url="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-
-          if git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
-            git clone --depth 1 --branch gh-pages "$remote_url" "$publish_dir"
-          else
-            git init "$publish_dir"
-            (
-              cd "$publish_dir"
-              git checkout --orphan gh-pages
-              git remote add origin "$remote_url"
-            )
-          fi
-
-          cp "${GITHUB_WORKSPACE}/GraemeBlair-CV.pdf" "$publish_dir/GraemeBlair-CV.pdf"
-
-          cd "$publish_dir"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add GraemeBlair-CV.pdf
-
-          if git diff --cached --quiet; then
-            echo "No PDF changes to commit."
+          if git diff --quiet -- GraemeBlair-CV.pdf; then
+            echo "PDF unchanged; nothing to publish."
             exit 0
           fi
 
+          git add GraemeBlair-CV.pdf
           git commit -m "Update CV PDF from ${GITHUB_SHA}"
-          git push origin HEAD:gh-pages
+
+          branch="${GITHUB_REF_NAME}"
+          for attempt in 1 2 3 4 5; do
+            if git push origin "HEAD:${branch}"; then
+              echo "Published GraemeBlair-CV.pdf to ${branch}."
+              exit 0
+            fi
+            echo "Push attempt ${attempt} failed; rebasing on ${branch} and retrying."
+            git fetch origin "${branch}"
+            git rebase "origin/${branch}"
+            sleep $((attempt * 2))
+          done
+
+          echo "::error::Could not push the rebuilt CV PDF to ${branch}."
+          exit 1

--- a/.github/workflows/cv-pdf.yml
+++ b/.github/workflows/cv-pdf.yml
@@ -7,11 +7,10 @@ on:
       - GraemeBlair-CV.tex
       - .github/workflows/cv-pdf.yml
       - .github/fonts/**
-  pull_request:
-    paths:
-      - GraemeBlair-CV.tex
-      - .github/workflows/cv-pdf.yml
-      - .github/fonts/**
+
+# Note: there is deliberately no pull_request trigger. Branches in this
+# repository are pushed directly, so a pull_request trigger would only start a
+# second, identical macOS build of the same commit.
 
 concurrency:
   group: cv-pdf-${{ github.ref }}
@@ -118,33 +117,42 @@ jobs:
           if-no-files-found: warn
 
       - name: Publish PDF to the site
-        # Only the default branch is published. Feature branches and pull
-        # requests build for verification but must not overwrite the live PDF.
-        if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        # Only the default branch is published. Other branches build for
+        # verification but must not overwrite the live PDF.
+        if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         run: |
           set -euo pipefail
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          if git diff --quiet -- GraemeBlair-CV.pdf; then
-            echo "PDF unchanged; nothing to publish."
-            exit 0
-          fi
-
-          git add GraemeBlair-CV.pdf
-          git commit -m "Update CV PDF from ${GITHUB_SHA}"
-
           branch="${GITHUB_REF_NAME}"
+          built_pdf="${RUNNER_TEMP}/GraemeBlair-CV.pdf"
+          cp GraemeBlair-CV.pdf "$built_pdf"
+
           for attempt in 1 2 3 4 5; do
+            # Re-anchor on the current remote tip each attempt, then drop the
+            # freshly built PDF on top. The commit only ever touches this one
+            # file, so this cannot conflict with concurrent pushes.
+            git fetch --depth=1 origin "$branch"
+            git checkout -q -B cv-publish FETCH_HEAD
+            cp "$built_pdf" GraemeBlair-CV.pdf
+
+            if git diff --quiet -- GraemeBlair-CV.pdf; then
+              echo "PDF unchanged; nothing to publish."
+              exit 0
+            fi
+
+            git add GraemeBlair-CV.pdf
+            git commit -q -m "Update CV PDF from ${GITHUB_SHA}"
+
             if git push origin "HEAD:${branch}"; then
               echo "Published GraemeBlair-CV.pdf to ${branch}."
               exit 0
             fi
-            echo "Push attempt ${attempt} failed; rebasing on ${branch} and retrying."
-            git fetch origin "${branch}"
-            git rebase "origin/${branch}"
-            sleep $((attempt * 2))
+
+            echo "Push attempt ${attempt} failed; retrying against the new tip."
+            sleep $((attempt * 3))
           done
 
           echo "::error::Could not push the rebuilt CV PDF to ${branch}."

--- a/GraemeBlair-CV.tex
+++ b/GraemeBlair-CV.tex
@@ -22,14 +22,10 @@
 \usepackage{xunicode}
 \usepackage{xltxtra}
 \defaultfontfeatures{Mapping=tex-text} % converts LaTeX specials (``quotes'' --- dashes etc.) to unicode
-\IfFontExistsTF{Hoefler Text}{%
-\setromanfont [Ligatures={Common}, BoldFont={Hoefler Text Black}, ItalicFont={Hoefler Text Italic}]{Hoefler Text}%
-}{%
-\setromanfont[Ligatures={Common}]{TeX Gyre Pagella}%
-}
-\setmonofont[Scale=0.8]{Latin Modern Mono}
+\setromanfont [Ligatures={Common}, BoldFont={Hoefler Text Black}, ItalicFont={Hoefler Text Italic}]{Hoefler Text}
+\setmonofont[Scale=0.8]{Monaco} 
 % ---- CUSTOM AMPERSAND
-\newcommand{\amper}{{\IfFontExistsTF{Gentium Basic Italic}{\fontspec[Scale=.95]{Gentium Basic Italic}}{\fontspec[Scale=.95]{TeX Gyre Pagella}}\selectfont\itshape\&}}
+\newcommand{\amper}{{\fontspec[Scale=.95]{Gentium Basic Italic}\selectfont\itshape\&}}
 % ---- MARGIN YEARS
 \usepackage{marginnote}
 \newcommand{\years}[1]{\marginnote{\scriptsize #1}}
@@ -79,7 +75,7 @@
 {\large  Current appointments}\donotbreakhere
 \begin{indnt}
 Fellow, Center for Advanced Study in the Behavioral Sciences, Stanford University, 2026--27\\[.75em]
-Professor of Political Science, UCLA, 2025-- \hspace{0.1em}(on leave 2026-27) \\[.75em]
+Professor of Political Science, UCLA, 2025-- (on leave 2026-27) \\[.75em]
 Co-Director, \href{https://deportationdata.org}{Deportation Data Project}, 2024--
 \end{indnt}
 \vspace{1.5em}


### PR DESCRIPTION
Two related pieces of work on the CV. The build fix came first; the content addition rides along because it needs the fixed build to produce a correct PDF.

---

# Part 1 — Build the CV PDF on macOS so it keeps its Hoefler Text typography

## What was wrong

**1. The fonts were substituted.** `GraemeBlair-CV.tex` is set in Hoefler Text (with `Hoefler Text Black` for bold and `Hoefler Text Italic` for italic) and Monaco. Those are macOS system fonts and are not redistributable, so they can't be vendored into this repo and installed on a Linux runner. Earlier fixes worked around that by falling back to TeX Gyre Pagella and Latin Modern Mono. Measured against the currently published PDF:

| | Fonts | Pages |
|---|---|---|
| Published (Ubuntu build) | TeX Gyre Pagella | 10 |
| Local build / reference | Hoefler Text | 9 |

**2. The most recent run failed outright.** It switched to `macos-latest` but kept `xu-cheng/latex-action`, which is a Docker container action and can only run on Linux. It aborted before compiling:

> `You cannot use a endToken that is an empty string, the string 'pause-logging', or another workflow command.`

**3. The branch gating was inverted.** `gh-pages` is the default branch and holds both the LaTeX source and the site. The job carried `if: github.ref != 'refs/heads/gh-pages'`, so editing the CV on the default branch never rebuilt it (that run shows as `skipped`), while a push to *any* feature branch rebuilt from that branch's `.tex` and overwrote the live PDF.

## What changed

- Build on `macos-latest` with a real TeX Live install (`mactex-no-gui`) instead of the Docker action, so XeTeX resolves Hoefler Text and Monaco from the runner's system fonts. `mactex-no-gui` is a single download rather than BasicTeX + `tlmgr`, so the build doesn't depend on CTAN mirror availability.
- Restore the original font declarations in `GraemeBlair-CV.tex`, dropping the `\IfFontExistsTF` fallbacks and the `\hspace{0.1em}` that was compensating for the substituted font.
- Two guards so a font regression fails the build instead of quietly publishing a wrong-looking PDF: a font probe before compiling, and a check afterwards that the `HoeflerText(0)` and `Monaco(0)` families were actually created.
- Publish only from the default branch. The publish step re-anchors on the current remote tip on each retry and copies the built PDF on top, instead of rebasing inside `actions/checkout`'s shallow clone.
- No `pull_request` trigger: branches here are pushed directly, so it only started a second identical macOS build of the same commit.
- Add a `concurrency` group, upload the PDF and log as artifacts, and move to `actions/checkout@v5`.

## Verification

Green runs on this branch: [30200963797](https://github.com/graemeblair/web/actions/runs/30200963797), [30201242702](https://github.com/graemeblair/web/actions/runs/30201242702), [30202571547](https://github.com/graemeblair/web/actions/runs/30202571547).

The artifact PDF was compared against a reference build of the same source:

- 9 pages, matching the reference (vs 10 for the substituted-font build)
- Embedded fonts `HoeflerText-Regular`, `HoeflerText-Italic`, `CMSY10` — identical to the reference
- Extracted text identical on all 9 pages
- Rendered at 100 dpi, **0.0000% of pixels differ from the reference on every page**

Every run correctly `skipped` the publish step, confirming a non-default branch cannot overwrite the live PDF. The publish path itself runs on merge to `gh-pages`.

## Note on fonts

The Hoefler Text and Monaco font files are deliberately **not** committed here — they're Apple-licensed. The build relies on the macOS runner's own system fonts, which is why it can't move back to Ubuntu without changing the CV's typography. The trade-off is runtime: installing TeX Live takes ~6 minutes, so a run is ~7 minutes rather than ~1.

---

# Part 2 — Add the Khalil Third Circuit § 1227(a)(4)(C) declaration

A search of the public record turned up one declaration missing from **both** the CV and the Expert work page on the site.

**Khalil v. Trump, Nos. 25-2162 & 25-2357, U.S. Court of Appeals for the Third Circuit — filed September 17, 2025, with David Hausman.**

- Filed as **Appendix II** to the *Brief of Immigration Lawyers, Law Professors, and Scholars as Amici Curiae in Support of Petitioner-Appellee* (Case 25-2162, Document 87-1).
- It is **separately captioned for the Third Circuit and separately sworn** under 28 U.S.C. § 1746 (Document 87-3), not a re-filing — the March 2025 D.N.J. `Khalil v. Joyce` declaration appears alongside it as an exhibit. This parallels the existing pair of `Mahdawi` entries (D. Vt., then Second Circuit).
- It supports the brief's Argument III: *"Amici are unaware of the government having ever relied on 8 U.S.C. § 1227(a)(4)(C) to deport a permanent resident for political speech."*

Also adds the **December 2025** date to the `D.N.N.` entry on the Expert work page — the only entry there that lacked one.

### Cases checked and ruled out

- **Öztürk v. Hyde** (2d Cir. No. 25-1019) — the scholars' amicus brief contains no Blair/Hausman citation, despite the same counsel team and the same deportability ground.
- **AAUP v. Rubio** (D. Mass.), **Khan Suri v. Trump** (E.D. Va./4th Cir.) — no declaration found.
- No cert-stage filing found. Rehearing en banc was denied May 22, 2026 and the mandate stayed May 26, 2026 pending certiorari, so a Supreme Court amicus may yet appear.

Public-record searching only — CourtListener full-text search returned HTTP 403, so sealed or un-indexed filings wouldn't surface.

## Verification

Run [30202571547](https://github.com/graemeblair/web/actions/runs/30202571547) is green: the rebuilt PDF is still **9 pages**, still Hoefler Text, and contains the new entry in reverse-chronological position. The site's `§1227(a)(4)(C)` list is tag-balanced and the linked amicus PDF returns HTTP 200.

## Two things left for you to decide

Deliberately **not** changed, since only you know the underlying facts:

1. **`D.N.N.` caption mismatch.** The CV says `D.N.N. et al. v. Bacon et al.`; the site says `D.N.N. et al. v. Liggins et al.` The live docket (1:25-cv-01613-JRR, D. Md.) is captioned **Liggins**, so the CV line looks stale — but "Bacon" may be correct as of your December 2025 filing.
2. **`Mahdawi` Second Circuit date.** Both files say September 2025; the amicus brief carrying that declaration was docketed **August 25, 2025** (No. 25-1113, DktEntry 157.2).