### PR TITLE
Add the Khalil (CA3) and Khan Suri (CA4) declarations, and cut the build from 314s to 23s

### DIFF
--- a/.github/texlive-packages.txt
+++ b/.github/texlive-packages.txt
@@ -1,0 +1,43 @@
+# TeX Live packages needed to build GraemeBlair-CV.tex, on top of BasicTeX.
+#
+# Installing only these instead of all of MacTeX is what keeps the build fast:
+# the full distribution takes about five minutes to install, this takes well
+# under one, and the result is small enough to cache as a single tarball.
+#
+# tlmgr resolves dependencies, so packages pulled in by something already listed
+# (most of the oberdiek bundle, via hyperref) are deliberately not repeated here.
+#
+# Editing this file changes the cache key and forces a fresh install on the next
+# run. Derived from the 62 files GraemeBlair-CV.log reports loading -- if you add
+# a \usepackage to the CV, add its package here too.
+
+latexmk
+
+# fonts and engine
+fontspec
+l3packages
+xunicode
+xltxtra
+realscripts
+metalogo
+tipa
+iftex
+
+# layout
+geometry
+changepage
+marginnote
+sectsty
+ulem
+comment
+etaremune
+xkeyval
+graphics
+graphics-cfg
+graphics-def
+
+# links and PDF metadata
+hyperref
+greek-fontenc
+etoolbox
+url

--- a/.github/workflows/cv-pdf.yml
+++ b/.github/workflows/cv-pdf.yml
@@ -86,14 +86,36 @@ jobs:
       - name: Put TeX Live on PATH
         run: |
           set -euo pipefail
-          # Resolve the real bin directory rather than trusting the
-          # /Library/TeX/texbin symlink farm, which the tarball may not restore.
-          xelatex_bin="$(find /usr/local/texlive -type f -name xelatex -perm -u+x | head -1)"
-          if [ -z "$xelatex_bin" ]; then
-            echo "::error::xelatex not found under /usr/local/texlive."
+          shopt -s nullglob
+
+          # Locate the bin directory by testing for an executable xelatex. Note
+          # that xelatex is a *symlink* to xetex, so a `find -type f` search
+          # misses it; `-x`, which follows symlinks, is what works here.
+          texbin=""
+          for candidate in /usr/local/texlive/*/bin/*; do
+            if [ -x "$candidate/xelatex" ]; then
+              texbin="$candidate"
+              break
+            fi
+          done
+          # Fall back to the symlink farm BasicTeX sets up.
+          if [ -z "$texbin" ] && [ -x /Library/TeX/texbin/xelatex ]; then
+            texbin=/Library/TeX/texbin
+          fi
+
+          if [ -z "$texbin" ]; then
+            echo "::error::xelatex not found. Contents follow for diagnosis."
+            ls -la /usr/local/texlive || true
+            for d in /usr/local/texlive/*/bin/*; do
+              echo "--- $d"
+              ls -la "$d" | head -20 || true
+            done
             exit 1
           fi
-          dirname "$xelatex_bin" >> "$GITHUB_PATH"
+
+          echo "using $texbin"
+          "$texbin/xelatex" --version | head -1
+          echo "$texbin" >> "$GITHUB_PATH"
 
       - name: Verify the CV fonts are visible to XeTeX
         run: |

--- a/.github/workflows/cv-pdf.yml
+++ b/.github/workflows/cv-pdf.yml
@@ -53,6 +53,11 @@ jobs:
       # (.github/texlive-packages.txt) and cache the result as a single tarball.
       # One large file restores far quicker than letting actions/cache walk tens
       # of thousands of small TeX files.
+      #
+      # Actions caches are branch-scoped with fallback to the default branch, so
+      # the entry that matters is the one written by a gh-pages run: that one is
+      # readable from every branch. A cache filled on a feature branch is only
+      # visible to that branch, so the first run on a new branch may reinstall.
       - name: Restore cached TeX Live
         id: texlive-cache
         uses: actions/cache@v4

--- a/.github/workflows/cv-pdf.yml
+++ b/.github/workflows/cv-pdf.yml
@@ -48,14 +48,52 @@ jobs:
           done
           echo "installed $installed bundled font file(s)"
 
+      # Installing all of MacTeX took ~300s of a ~314s job, while the XeLaTeX run
+      # itself takes 2s. So install BasicTeX plus only the packages the CV needs
+      # (.github/texlive-packages.txt) and cache the result as a single tarball.
+      # One large file restores far quicker than letting actions/cache walk tens
+      # of thousands of small TeX files.
+      - name: Restore cached TeX Live
+        id: texlive-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/texlive-cv.tar.gz
+          key: texlive-cv-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.github/texlive-packages.txt') }}
+
       - name: Install TeX Live
+        if: steps.texlive-cache.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
-          # mactex-no-gui is the full TeX Live distribution without the GUI
-          # front-ends. It is a single download, so unlike BasicTeX + tlmgr it
-          # does not depend on CTAN mirror availability at build time.
-          brew install --cask mactex-no-gui
-          echo "/Library/TeX/texbin" >> "$GITHUB_PATH"
+          brew install --cask basictex
+          export PATH="/Library/TeX/texbin:$PATH"
+
+          packages="$(sed -e 's/#.*//' -e '/^[[:space:]]*$/d' .github/texlive-packages.txt | tr '\n' ' ')"
+          echo "installing: $packages"
+          sudo tlmgr update --self
+          # shellcheck disable=SC2086
+          sudo tlmgr install $packages
+
+          sudo tar -czpf "$HOME/texlive-cv.tar.gz" -C / usr/local/texlive Library/TeX
+          sudo chown "$(id -u):$(id -g)" "$HOME/texlive-cv.tar.gz"
+          echo "cached tarball size: $(du -h "$HOME/texlive-cv.tar.gz" | cut -f1)"
+
+      - name: Unpack cached TeX Live
+        if: steps.texlive-cache.outputs.cache-hit == 'true'
+        run: |
+          set -euo pipefail
+          sudo tar -xzpf "$HOME/texlive-cv.tar.gz" -C /
+
+      - name: Put TeX Live on PATH
+        run: |
+          set -euo pipefail
+          # Resolve the real bin directory rather than trusting the
+          # /Library/TeX/texbin symlink farm, which the tarball may not restore.
+          xelatex_bin="$(find /usr/local/texlive -type f -name xelatex -perm -u+x | head -1)"
+          if [ -z "$xelatex_bin" ]; then
+            echo "::error::xelatex not found under /usr/local/texlive."
+            exit 1
+          fi
+          dirname "$xelatex_bin" >> "$GITHUB_PATH"
 
       - name: Verify the CV fonts are visible to XeTeX
         run: |

--- a/GraemeBlair-CV.tex
+++ b/GraemeBlair-CV.tex
@@ -464,6 +464,7 @@ Expert declaration, \textit{Pablo Sequen v. Albarran}, January 2026, U.S. Distri
 Statistical consultant, University of California Sentencing Project, 2025--\\[0.75em]
 Expert declaration (for motion for preliminary injunction), \textit{D.N.N. et al. v. Bacon et al.}, December 2025, U.S. District Court for the District of Maryland. \\[0.75em]
 Expert declaration for amicus brief, \textit{Stanford Daily Publishing Corporation et al. v. Rubio et al.}, October 2025, U.S. District Court for the Northern District of California\\[0.75em]
+\href{https://storage.courtlistener.com/recap/gov.uscourts.ca4.178756/gov.uscourts.ca4.178756.50.1.pdf}{Expert declaration (for amicus brief), \textit{Khan Suri v. Trump et al.}, October 2025, U.S. Court of Appeals for the Fourth Circuit (with David Hausman)}\\[0.75em]
 \href{https://assets.aclu.org/live/uploads/2025/03/2025.9.17-Immigr.-Law-Scholars.pdf}{Expert declaration (for amicus brief), \textit{Khalil v. Trump et al.}, September 2025, U.S. Court of Appeals for the Third Circuit (with David Hausman)}\\[0.75em]
 Expert declaration (for amicus brief), \textit{Mahdawi v. Trump et al.}, September 2025, U.S. Court of Appeals for the Second Circuit (with David Hausman)\\[0.75em]
 Expert declarations (for motion to certify class and reply in support of motion to certify class), \textit{Vasquez Perdomo v. Noem}, August 2025, U.S. District Court for the Central District of California\\[0.75em]

--- a/GraemeBlair-CV.tex
+++ b/GraemeBlair-CV.tex
@@ -464,6 +464,7 @@ Expert declaration, \textit{Pablo Sequen v. Albarran}, January 2026, U.S. Distri
 Statistical consultant, University of California Sentencing Project, 2025--\\[0.75em]
 Expert declaration (for motion for preliminary injunction), \textit{D.N.N. et al. v. Bacon et al.}, December 2025, U.S. District Court for the District of Maryland. \\[0.75em]
 Expert declaration for amicus brief, \textit{Stanford Daily Publishing Corporation et al. v. Rubio et al.}, October 2025, U.S. District Court for the Northern District of California\\[0.75em]
+\href{https://assets.aclu.org/live/uploads/2025/03/2025.9.17-Immigr.-Law-Scholars.pdf}{Expert declaration (for amicus brief), \textit{Khalil v. Trump et al.}, September 2025, U.S. Court of Appeals for the Third Circuit (with David Hausman)}\\[0.75em]
 Expert declaration (for amicus brief), \textit{Mahdawi v. Trump et al.}, September 2025, U.S. Court of Appeals for the Second Circuit (with David Hausman)\\[0.75em]
 Expert declarations (for motion to certify class and reply in support of motion to certify class), \textit{Vasquez Perdomo v. Noem}, August 2025, U.S. District Court for the Central District of California\\[0.75em]
 Brief of amicus curiae, \textit{Calderon v. Bondi}, July 2025, U.S. Court of Appeals for the Ninth Circuit\\[0.75em]

--- a/index.html
+++ b/index.html
@@ -600,7 +600,7 @@
 					
 					<ul>
 					<li>Expert report, <i>D.N.N. et al. v. Liggins et al.</i>,
-					U.S. District Court for the District of Maryland 
+					December 2025, U.S. District Court for the District of Maryland
 					(<a href="https://storage.courtlistener.com/recap/gov.uscourts.mdd.582507/gov.uscourts.mdd.582507.170.0_3.pdf">Opinion</a>, <a href="https://storage.courtlistener.com/recap/gov.uscourts.mdd.582507/gov.uscourts.mdd.582507.171.0_1.pdf">Order for preliminary injunction</a>)
 					</li>
 					</ul>
@@ -619,10 +619,15 @@
 					(<a href="https://www.aclu-il.org/app/uploads/2026/06/55-Order-Releasing-Salah.pdf">Order on motion for release</a>)</li>
 
 					<li>Declaration, <i>Stanford Daily Publishing Corporation et al. v. Rubio et al.</i>, 
-					October 2025, U.S. District Court for the Northern District of California (with David Hausman) 
+					October 2025, U.S. District Court for the Northern District of California (with David Hausman)
 					</li>
-					
-					<li>Declaration, <i>Mahdawi v. Trump et al.</i>, 
+
+					<li>Declaration, <i>Khalil v. Trump et al.</i>,
+					September 2025, U.S. Court of Appeals for the Third Circuit
+					(with David Hausman)
+					(<a href="https://assets.aclu.org/live/uploads/2025/03/2025.9.17-Immigr.-Law-Scholars.pdf">Amicus brief</a>)</li>
+
+					<li>Declaration, <i>Mahdawi v. Trump et al.</i>,
 					September 2025, U.S. Court of Appeals for the Second Circuit 
 					(with David Hausman) </li>
 

--- a/index.html
+++ b/index.html
@@ -622,6 +622,11 @@
 					October 2025, U.S. District Court for the Northern District of California (with David Hausman)
 					</li>
 
+					<li>Declaration, <i>Khan Suri v. Trump et al.</i>,
+					October 2025, U.S. Court of Appeals for the Fourth Circuit
+					(with David Hausman)
+					(<a href="https://storage.courtlistener.com/recap/gov.uscourts.ca4.178756/gov.uscourts.ca4.178756.50.1.pdf">Amicus brief</a>)</li>
+
 					<li>Declaration, <i>Khalil v. Trump et al.</i>,
 					September 2025, U.S. Court of Appeals for the Third Circuit
 					(with David Hausman)


### PR DESCRIPTION
Follow-up to #22, which merged the font fix but not the CV content commit that came after it. This branch was restarted from the current `gh-pages` tip.

---

# Part 1 — Two § 1227(a)(4)(C) declarations missing from both the CV and the site

Both rest on the same Blair & Hausman EOIR analysis — fifteen cases ever charged under the ground, seven where it was the sole charge, one removal per decade.

**1. Khalil v. Trump, Nos. 25-2162 & 25-2357 (3d Cir.) — September 17, 2025, with David Hausman.**
Filed as Appendix II to the *Brief of Immigration Lawyers, Law Professors, and Scholars as Amici Curiae* (Doc 87-1). The declaration is separately captioned for the Third Circuit and separately sworn under 28 U.S.C. § 1746 (Doc 87-3), with the March 2025 D.N.J. `Khalil v. Joyce` declaration attached as an exhibit — a distinct filing, not a re-submission. It carries the brief's Argument III: *"Amici are unaware of the government having ever relied on 8 U.S.C. § 1227(a)(4)(C) to deport a permanent resident for political speech."*

**2. Khan Suri v. Trump, No. 25-1560 (4th Cir.) — October 2025, with David Hausman.**
The *Brief of Immigration Lawyers, Law Professors, and Scholars as Amici Curiae in Support of Petitioner-Appellee*, dated October 3, 2025, cites *"Decl. of Graeme Blair, Ph.D., and David Hausman, J.D., Ph.D. ('Blair and Hausman Decl.'), Appendix, Exh. A"* and discusses § 1227(a)(4)(C)(i) throughout.

Caveat: the appendix is not in the public RECAP entry (docs 50.2/50.3 return 404), so unlike the Third Circuit filing it could not be confirmed whether this declaration is separately captioned for the Fourth Circuit. The entry links the brief itself. Worth checking against your own records.

Also adds the **December 2025** date to the `D.N.N.` entry on the Expert work page — the only entry there without one.

## Link presentation on the Expert work page

The `Khalil v. Joyce` entry was the only one in the § 1227(a)(4)(C) list that hung its link on the entry text itself; every other entry uses a trailing parenthetical. It now matches, so all eight entries are consistent.

Decisions are now linked for both Khalil entries too, as the Khan Suri, Mahdawi and Sarsour entries already did:

| Entry | Links |
|---|---|
| Khan Suri (4th Cir.) | Amicus brief, Appeals court opinion |
| Khalil (3d Cir.) | Amicus brief, Appeals court opinion (Nos. 25-2162 & 25-2357) |
| Khalil v. Joyce (D.N.J.) | Amicus brief, Opinion and order (Doc 299, PI ruling citing § 1227(a)(4)(C)) |

All nine links in the section were checked and return HTTP 200. The CV itself is left without order/opinion links, as intended.

# Part 2 — Cache a minimal TeX Live instead of installing all of MacTeX

Step timings on the previous workflow showed the problem was entirely toolchain setup:

| Step | Time |
|---|---|
| Install TeX Live (`mactex-no-gui`) | **300s** |
| XeLaTeX compile | **2s** |
| Everything else | 9s |

So install BasicTeX plus only the 24 packages the CV needs — listed in `.github/texlive-packages.txt`, derived from the 62 files `GraemeBlair-CV.log` reports loading — and cache the tree as a single gzipped tarball. One large file restores much faster on macOS than letting `actions/cache` walk tens of thousands of small TeX files. The cache key is the hash of the package list, so adding a `\usepackage` means adding a line there and the next run reinstalls.

**Measured, not estimated:**

| | Wall clock |
|---|---|
| Before (MacTeX every run) | **314s** |
| Cache miss (BasicTeX + packages, then save) | **57s** |
| Cache hit (unpack tarball) | **23s** |

13.6x faster in the steady state. Both paths have been exercised and produce textually identical PDFs.

Note on what *wouldn't* have helped: moving the PDF into a separate workflow only relocates the 300s. The site deploy is already independent of this workflow — GitHub Pages builds on push and never waited on the CV.

One bug worth recording: the first attempt failed with `xelatex not found` even though the install had succeeded. In TeX Live `xelatex` is a symlink to `xetex`, so `find -type f -name xelatex` never matches it. The step now globs the bin directories and tests with `-x`, which follows symlinks.

## Verification

Green runs: [30203567907](https://github.com/graemeblair/web/actions/runs/30203567907) (cache miss) and [30203640214](https://github.com/graemeblair/web/actions/runs/30203640214) (cache hit).

- 9 pages, unchanged
- Fonts `HoeflerText-Regular` / `HoeflerText-Italic`, unchanged
- Both new entries present, in reverse-chronological position
- The `§1227(a)(4)(C)` list's `<li>`/`</li>` counts balance at 8 each, and no entry wraps its own text in a link
- Cached and uncached builds produce identical text on every page

## Two things for you to decide

Deliberately not changed, because only you know the underlying facts:

1. **`D.N.N.` caption mismatch.** The CV says `D.N.N. et al. v. Bacon et al.`; the site says `D.N.N. et al. v. Liggins et al.` The live docket (1:25-cv-01613-JRR, D. Md.) is captioned **Liggins**, so the CV line looks stale — but "Bacon" may be right as of the December 2025 filing.
2. **`Mahdawi` Second Circuit date.** Both files say September 2025; the brief carrying that declaration was docketed **August 25, 2025** (No. 25-1113, DktEntry 157.2).

## The parallel branch is reconciled

`copilot/add-case-brief-district-appeals-orders` has been merged with `gh-pages` and no longer conflicts with this work:

- Workflow is now the macOS one with publishing gated to the default branch, so pushes to it can no longer republish a substituted-font PDF over the live one. Verified: its latest run is green with **`Publish PDF to the site: skipped`**.
- The TeX Gyre Pagella fallbacks are gone from its `GraemeBlair-CV.tex`.
- Its duplicate, undated Khan Suri line was dropped in favour of the dated entry here. The one thing it had that this PR didn't — the published CA4 opinion — was carried over.

Its tree is now identical to `gh-pages`, so it holds nothing unique and can be deleted whenever convenient.