### PR TITLE
Expert work page: parenthetical links throughout, and link the Khalil and Khan Suri decisions

### DIFF
--- a/index.html
+++ b/index.html
@@ -625,7 +625,7 @@
 					<li>Declaration, <i>Khan Suri v. Trump et al.</i>,
 					October 2025, U.S. Court of Appeals for the Fourth Circuit
 					(with David Hausman)
-					(<a href="https://storage.courtlistener.com/recap/gov.uscourts.ca4.178756/gov.uscourts.ca4.178756.50.1.pdf">Amicus brief</a>)</li>
+					(<a href="https://storage.courtlistener.com/recap/gov.uscourts.ca4.178756/gov.uscourts.ca4.178756.50.1.pdf">Amicus brief</a>, <a href="https://storage.courtlistener.com/recap/gov.uscourts.ca4.178756/gov.uscourts.ca4.178756.133.0.pdf">Appeals court opinion</a>)</li>
 
 					<li>Declaration, <i>Khalil v. Trump et al.</i>,
 					September 2025, U.S. Court of Appeals for the Third Circuit

--- a/index.html
+++ b/index.html
@@ -630,7 +630,7 @@
 					<li>Declaration, <i>Khalil v. Trump et al.</i>,
 					September 2025, U.S. Court of Appeals for the Third Circuit
 					(with David Hausman)
-					(<a href="https://assets.aclu.org/live/uploads/2025/03/2025.9.17-Immigr.-Law-Scholars.pdf">Amicus brief</a>)</li>
+					(<a href="https://assets.aclu.org/live/uploads/2025/03/2025.9.17-Immigr.-Law-Scholars.pdf">Amicus brief</a>, <a href="https://www2.ca3.uscourts.gov/opinarch/252162p.pdf">Appeals court opinion</a>)</li>
 
 					<li>Declaration, <i>Mahdawi v. Trump et al.</i>,
 					September 2025, U.S. Court of Appeals for the Second Circuit 
@@ -645,10 +645,10 @@
 					March 2025, U.S. District Court for the Southern District of New York 
 					(with David Hausman)</li>
 					
-					<li><a href="https://ccrjustice.org/sites/default/files/attach/2025/03/110-1_3-24-25_Immigration-amicus-brief_w.pdf">
-					  Declaration, <i>Khalil v. Joyce et al.</i></a>, 
-					March 2025, U.S. District Court for the District of New Jersey 
-					(with David Hausman)</li>
+					<li>Declaration, <i>Khalil v. Joyce et al.</i>,
+					March 2025, U.S. District Court for the District of New Jersey
+					(with David Hausman)
+					(<a href="https://ccrjustice.org/sites/default/files/attach/2025/03/110-1_3-24-25_Immigration-amicus-brief_w.pdf">Amicus brief</a>, <a href="https://storage.courtlistener.com/recap/gov.uscourts.njd.564334/gov.uscourts.njd.564334.299.0.pdf">Opinion and order</a>)</li>
 						
 					</ul>
 


### PR DESCRIPTION
Picks up the two commits that missed the #23 merge. #23 merged at head `cb0cb923` (13:18:04Z) while these two were pushed just after, so they never reached `gh-pages`.

**Nothing else is outstanding** — after this, my branch and `gh-pages` are identical. Safe to merge without racing me again.

## What is already live from #23

- CV PDF: 9 pages, Hoefler Text, with both the Khalil (3d Cir.) and Khan Suri (4th Cir.) entries — verified against the served file at 71,111 bytes
- Expert work page: both entries, plus the December 2025 date on `D.N.N.`
- The BasicTeX + cached-tarball workflow

## What this PR adds — `index.html` only

Two commits, both touching only the § 1227(a)(4)(C) list:

1. **`Khalil v. Joyce` now uses a parenthetical link.** It was the only entry in the list hanging its link on the entry text (`<a>Declaration, Khalil v. Joyce et al.</a>`); every other entry puts links in a trailing parenthetical. All eight entries are now consistent.
2. **Decisions linked for both Khalil entries and Khan Suri**, matching what the Mahdawi and Sarsour entries already did:

| Entry | Links |
|---|---|
| Khan Suri (4th Cir.) | Amicus brief, Appeals court opinion |
| Khalil (3d Cir.) | Amicus brief, Appeals court opinion |
| Khalil v. Joyce (D.N.J.) | Amicus brief, Opinion and order |

Two notes on the documents chosen, since the URLs are not self-describing:

- For the Third Circuit, `252162p.pdf` is the 70-page panel opinion in Nos. 25-2162 & 25-2357. Not `252162po.pdf`, which despite the similar name is the order denying rehearing en banc.
- For the District of New Jersey, Doc 299 is Judge Farbiarz's 14-page Opinion and Order on the preliminary injunction (filed 06/11/25), which cites 8 U.S.C. § 1227(a)(4)(C) directly.

The CV is untouched — order and opinion links are deliberately kept off it.

## Verification

Checked on the branch:

- The list has 8 `<li>` and 8 `</li>`
- No entry wraps its own text in an `<a>`
- All three new links present
- Every link in the section was fetched and each PDF opened to confirm it is the document it is labelled as, not just that the URL resolves

No CV rebuild is triggered, since only `index.html` changes and the workflow's `paths` filter covers `GraemeBlair-CV.tex`, the workflow, and `.github/fonts`. The PDF is already correct on `gh-pages`.

## Still open, unchanged

1. **`D.N.N.` caption.** CV says `v. Bacon et al.`; the site and the live docket (1:25-cv-01613-JRR, D. Md.) say `v. Liggins et al.`
2. **`Mahdawi` Second Circuit date.** Both files say September 2025; the brief carrying that declaration was docketed August 25, 2025 (No. 25-1113, DktEntry 157.2).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PidPLmdGuiY2kV3MSfRYdf)_